### PR TITLE
Add use for exception handling

### DIFF
--- a/src/Request/Issue.php
+++ b/src/Request/Issue.php
@@ -3,6 +3,7 @@
 namespace JiraClient\Request;
 
 use JiraClient\JiraClient,
+    JiraClient\Exception\JiraException,
     JiraClient\Resource\Field,
     JiraClient\Resource\AbstractResource,
     JiraClient\Resource\ResourcesList,


### PR DESCRIPTION
I was using an invalid/missing issue type but because this error handling was broken I was getting an error on the error handling.

Error I experienced
-------------------------
PHP Fatal error: Class 'JiraClient\Request\JiraException' not found in /path/to/jira-client/src/Request/Issue.php on line 51

Error after fixing import
------------------------------
exception 'JiraClient\Exception\JiraException' with message 'Project 'JIRA' and issue type 'Suggestion' missing from create metadata in /path/to/jira-client/src/Request/Issue.php on line 52
followed by the stracktrace