### PR TITLE
added new data type "number"

### DIFF
--- a/src/Resource/AbstractResource.php
+++ b/src/Resource/AbstractResource.php
@@ -106,6 +106,10 @@ class AbstractResource
             return $data;
         }
 
+        if ($type == 'number') {
+            return $data;
+        }
+
         if ($type == 'assoc') {
             return $data;
         }


### PR DESCRIPTION
The latest version of JIRA also has a data type "number" which is used for e.g. story points in the Agile Plugin.

This PR adds number to the mapped data types, so that the field value is actually populated.